### PR TITLE
Update nginx "keepalive_requests" to 1000 (default since 1.19.10)

### DIFF
--- a/rootfs/etc/gotpl/nginx.conf.tmpl
+++ b/rootfs/etc/gotpl/nginx.conf.tmpl
@@ -32,7 +32,7 @@ http {
     port_in_redirect off;
     send_timeout 600;
     sendfile on;
-    keepalive_requests 100;
+    keepalive_requests 1000;
     keepalive_timeout 60;
     reset_timedout_connection off;
     server_tokens off;


### PR DESCRIPTION
The configuration `keepalive_requests` is also responsible for the http2 max requests in one connection since version 1.19.7. [1]. With the currelt value of 100 we have encountered some repeatable issues on some sites requesting many small files at once, and increasing the limit to 1000 completely fixed the issue. Furthermore since v1.19.10 the default value was updated [2] to 1000 also by nginx maintainers.

[1] http://nginx.org/en/docs/http/ngx_http_v2_module.html#http2_max_requests
[2] http://nginx.org/en/docs/http/ngx_http_core_module.html#keepalive_requests