### PR TITLE
Fix default certificate cron commands

### DIFF
--- a/rootfs/etc/gotpl/root.crontabs.tmpl
+++ b/rootfs/etc/gotpl/root.crontabs.tmpl
@@ -1,4 +1,4 @@
 SHELL=/bin/bash
 
-*/10 * * * * /usr/bin/with-contenv /opt/bin/default_cert_create
-0 0 * * 1 /usr/bin/with-contenv /opt/bin/default_cert_renew
+*/10 * * * * /command/with-contenv /opt/bin/default_cert_create
+0 0 * * 1 /command/with-contenv /opt/bin/default_cert_renew

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -85,6 +85,9 @@ docker exec "${container}" /usr/sbin/nginx -v 2>&1 | grep -F 'nginx/1.31.3'
 docker exec "${container}" /opt/wodby/bin/lego --version | grep -F 'v4.35.2-wodby.1'
 docker exec "${container}" /bin/sh -c 'test "$(cat /proc/1/comm)" = s6-svscan'
 docker exec "${container}" /bin/sh -c 'pidof nginx >/dev/null && pidof crond >/dev/null'
+docker exec "${container}" /bin/sh -c 'test -x /command/with-contenv'
+docker exec "${container}" grep -F '/command/with-contenv /opt/bin/default_cert_create' /etc/crontabs/root >/dev/null
+docker exec "${container}" grep -F '/command/with-contenv /opt/bin/default_cert_renew' /etc/crontabs/root >/dev/null
 docker exec "${container}" /bin/sh -c "ps | grep -q '[c]onfd .*etcdv3.*2379.*watch'"
 docker exec "${container}" /bin/sh -c '! apk info -e curl && ! apk info -e libcurl && ! apk info -e tar && ! apk info -e wget && ! apk info -e unzip'
 docker exec "${container}" /bin/sh -n /opt/bin/lego-dns-callback


### PR DESCRIPTION
## Summary

- use the s6-overlay v3 `/command/with-contenv` path for default certificate creation and renewal jobs
- verify the runtime helper and both generated crontab entries in the container test

## Root cause

Edge 3.x retained the legacy `/usr/bin/with-contenv` cron path after moving to s6-overlay v3. The cron daemon stayed healthy, but every default node-certificate creation and renewal command failed before invoking LEGO, leaving the bootstrap self-signed certificate active.

## Impact

New and renewed node-hostname certificates can run again on current Edge images. Application technical-domain DNS-01 issuance is unchanged.

## Validation

- `git diff --check`
- `bash -n tests/run.sh`
- focused compatibility check against `wodby/edge-alpine:3.0.1`
- full local image build reached LEGO compilation but Docker Desktop ran out of storage; GitHub CI is required to complete the clean full build and runtime suite before merge
