### PR TITLE
Remove inherited gotpl before replacement

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -118,6 +118,9 @@ RUN set -eux; \
     apk del 7zip curl gzip tar unzip wget; \
     rm -rf /tmp/* /var/cache/apk/*
 
+# Record a whiteout so layer-aware scanners discard the inherited vulnerable binary.
+RUN rm /usr/local/bin/gotpl
+
 COPY --from=lego-build /src/dist/lego /opt/wodby/bin/lego
 COPY --from=confd-build /confd /opt/wodby/tools/bin/confd
 COPY --from=gotpl-build /gotpl /usr/local/bin/gotpl


### PR DESCRIPTION
## Summary

Record an OCI whiteout for the vulnerable gotpl binary inherited from the nginx base before copying the Go 1.26.6 rebuild.

## Why

The prior security refresh rebuilt lego, confd, and gotpl and removed the vulnerable `golang.org/x/net` package plus the Go 1.26.5 findings. Docker Scout still indexed the hidden Go 1.26.4 gotpl package from the base layer because a direct `COPY` replacement does not record deletion metadata. Removing it in a separate layer makes the replacement explicit to layer-aware scanners.

## Validation

- `git diff --check`
- Docker BuildKit static build check passed with no warnings
- authoritative image build and runtime suite run in this PR
- Docker Scout runs again on merged `master` before tag `3.0.3` is created